### PR TITLE
Fix null JsonElement crash when loading world with no created backpacks

### DIFF
--- a/src/main/kotlin/tech/sethi/pebbles/backpack/BackpackCommands.kt
+++ b/src/main/kotlin/tech/sethi/pebbles/backpack/BackpackCommands.kt
@@ -1,6 +1,7 @@
 package tech.sethi.pebbles.backpack
 
 import com.google.gson.GsonBuilder
+import com.google.gson.JsonArray
 import com.google.gson.JsonParser
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.arguments.IntegerArgumentType
@@ -207,7 +208,10 @@ object BackpackCommands {
 
         file.reader().use { reader ->
             val jsonElement = JsonParser.parseReader(reader)
-            val backpackDataArray = jsonElement.asJsonArray
+            var backpackDataArray = JsonArray()
+            if (!jsonElement.isJsonNull) {
+                backpackDataArray = jsonElement.asJsonArray
+            }
 
             for (backpackDataJson in backpackDataArray) {
                 val backpackData = gson.fromJson(backpackDataJson, BackpackData::class.java)


### PR DESCRIPTION
Fix crash caused when loading back into a singleplayer world that has no created backpacks.

Also, I had to update `gradle.properties` with `loader_version=0.14.21` to be able to `runClient` due to dependencies, but I was unsure if that should be included in this PR.